### PR TITLE
Updating jekyll to use kramdown

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,6 +5,9 @@ permalink: /:categories/:year/:month/:day/:title
 exclude: [".rvmrc", ".rbenv-version", "README.md", "Rakefile", "changelog.md"]
 pygments: true
 
+# https://help.github.com/articles/migrating-your-pages-site-from-maruku
+markdown: kramdown
+
 # Themes are encouraged to use these universal variables 
 # so be sure to set them if your theme uses them.
 #


### PR DESCRIPTION
https://help.github.com/articles/migrating-your-pages-site-from-maruku
Currently when building the site, Github Pages replies with an email message warning of the impending demise of Maruku.
